### PR TITLE
support for mapping at keyPath

### DIFF
--- a/Source/ReactiveSwift/SignalProducer+ObjectMapper.swift
+++ b/Source/ReactiveSwift/SignalProducer+ObjectMapper.swift
@@ -22,6 +22,24 @@ extension SignalProducerProtocol where Value == Moya.Response, Error == MoyaErro
             return unwrapThrowable { try response.mapArray(type, context: context) }
         }
     }
+
+    /// Maps data received from the signal into an object which implements the Mappable protocol.
+    /// If the conversion fails, the signal errors.
+  public func mapObject<T: BaseMappable>(_ type: T.Type, atKeyPath keyPath: String, context: MapContext? = nil) -> SignalProducer<T, MoyaError> {
+        return producer.flatMap(.latest) {
+            (response: Response) -> SignalProducer<T, Error> in
+          return unwrapThrowable { try response.mapObject(type, atKeyPath: keyPath, context: context) }
+        }
+    }
+
+    /// Maps data received from the signal into an array of objects which implement the Mappable
+    /// protocol.
+    /// If the conversion fails, the signal errors.
+    public func mapArray<T: BaseMappable>(_ type: T.Type, atKeyPath keyPath: String, context: MapContext? = nil) -> SignalProducer<[T], MoyaError> {
+        return producer.flatMap(.latest) { (response: Response) -> SignalProducer<[T], Error> in
+            return unwrapThrowable { try response.mapArray(type, atKeyPath: keyPath, context: context) }
+        }
+    }
 }
 
 /// Maps throwable to SignalProducer

--- a/Source/Response+ObjectMapper.swift
+++ b/Source/Response+ObjectMapper.swift
@@ -30,6 +30,24 @@ public extension Response {
     return Mapper<T>(context: context).mapArray(JSONArray: array)
   }
 
+  /// Maps data received from the signal into an object which implements the Mappable protocol.
+  /// If the conversion fails, the signal errors.
+  public func mapObject<T: BaseMappable>(_ type: T.Type, atKeyPath keyPath: String, context: MapContext? = nil) throws -> T {
+    guard let object = Mapper<T>(context: context).map(JSONObject: (try mapJSON() as? NSDictionary)?.value(forKeyPath: keyPath)) else {
+      throw MoyaError.jsonMapping(self)
+    }
+    return object
+  }
+
+  /// Maps data received from the signal into an array of objects which implement the Mappable
+  /// protocol.
+  /// If the conversion fails, the signal errors.
+  public func mapArray<T: BaseMappable>(_ type: T.Type, atKeyPath keyPath: String, context: MapContext? = nil) throws -> [T] {
+    guard let array = (try mapJSON() as? NSDictionary)?.value(forKeyPath: keyPath) as? [[String : Any]] else {
+      throw MoyaError.jsonMapping(self)
+    }
+    return Mapper<T>(context: context).mapArray(JSONArray: array)
+  }
 }
 
 
@@ -49,6 +67,23 @@ public extension Response {
   /// If the conversion fails, the signal errors.
   public func mapArray<T: ImmutableMappable>(_ type: T.Type, context: MapContext? = nil) throws -> [T] {
     guard let array = try mapJSON() as? [[String : Any]] else {
+      throw MoyaError.jsonMapping(self)
+    }
+		return try Mapper<T>(context: context).mapArray(JSONArray: array)
+  }
+
+  /// Maps data received from the signal into an object which implements the ImmutableMappable
+  /// protocol.
+  /// If the conversion fails, the signal errors.
+  public func mapObject<T: ImmutableMappable>(_ type: T.Type, atKeyPath keyPath: String, context: MapContext? = nil) throws -> T {
+		return try Mapper<T>(context: context).map(JSONObject: (try mapJSON() as? NSDictionary)?.value(forKeyPath: keyPath))
+  }
+
+  /// Maps data received from the signal into an array of objects which implement the ImmutableMappable
+  /// protocol.
+  /// If the conversion fails, the signal errors.
+  public func mapArray<T: ImmutableMappable>(_ type: T.Type, atKeyPath keyPath: String, context: MapContext? = nil) throws -> [T] {
+    guard let array = (try mapJSON() as? NSDictionary)?.value(forKeyPath: keyPath) as? [[String : Any]] else {
       throw MoyaError.jsonMapping(self)
     }
 		return try Mapper<T>(context: context).mapArray(JSONArray: array)

--- a/Source/RxSwift/ObservableType+ObjectMapper.swift
+++ b/Source/RxSwift/ObservableType+ObjectMapper.swift
@@ -30,6 +30,24 @@ public extension ObservableType where E == Response {
 			return Observable.just(try response.mapArray(T.self, context: context))
     }
   }
+  
+  /// Maps data received from the signal into an object
+  /// which implements the Mappable protocol and returns the result back
+  /// If the conversion fails, the signal errors.
+  public func mapObject<T: BaseMappable>(_ type: T.Type, atKeyPath keyPath: String, context: MapContext? = nil) -> Observable<T> {
+    return flatMap { response -> Observable<T> in
+      return Observable.just(try response.mapObject(T.self, atKeyPath: keyPath, context: context))
+    }
+  }
+
+  /// Maps data received from the signal into an array of objects
+  /// which implement the Mappable protocol and returns the result back
+  /// If the conversion fails, the signal errors.
+	public func mapArray<T: BaseMappable>(_ type: T.Type, atKeyPath keyPath: String, context: MapContext? = nil) -> Observable<[T]> {
+    return flatMap { response -> Observable<[T]> in
+			return Observable.just(try response.mapArray(T.self, atKeyPath: keyPath, context: context))
+    }
+  }
 }
 
 
@@ -51,6 +69,24 @@ public extension ObservableType where E == Response {
   public func mapArray<T: ImmutableMappable>(_ type: T.Type, context: MapContext? = nil) -> Observable<[T]> {
     return flatMap { response -> Observable<[T]> in
 			return Observable.just(try response.mapArray(T.self, context: context))
+    }
+  }
+  
+  /// Maps data received from the signal into an object
+  /// which implements the ImmutableMappable protocol and returns the result back
+  /// If the conversion fails, the signal errors.
+  public func mapObject<T: ImmutableMappable>(_ type: T.Type, atKeyPath keyPath: String, context: MapContext? = nil) -> Observable<T> {
+    return flatMap { response -> Observable<T> in
+			return Observable.just(try response.mapObject(T.self, atKeyPath: keyPath, context: context))
+    }
+  }
+
+  /// Maps data received from the signal into an array of objects
+  /// which implement the ImmutableMappable protocol and returns the result back
+  /// If the conversion fails, the signal errors.
+  public func mapArray<T: ImmutableMappable>(_ type: T.Type, atKeyPath keyPath: String, context: MapContext? = nil) -> Observable<[T]> {
+    return flatMap { response -> Observable<[T]> in
+			return Observable.just(try response.mapArray(T.self, atKeyPath: keyPath, context: context))
     }
   }
 }

--- a/Source/RxSwift/Single+ObjectMapper.swift
+++ b/Source/RxSwift/Single+ObjectMapper.swift
@@ -30,6 +30,24 @@ public extension PrimitiveSequence where TraitType == SingleTrait, ElementType =
                     return Single.just(try response.mapArray(type, context: context))
                 }
     }
+
+    /// Maps data received from the signal into an object
+    /// which implements the Mappable protocol and returns the result back
+    /// If the conversion fails, the signal errors.
+  public func mapObject<T: BaseMappable>(_ type: T.Type, atKeyPath keyPath: String, context: MapContext? = nil) -> Single<T> {
+        return flatMap { response -> Single<T> in
+          return Single.just(try response.mapObject(type, atKeyPath: keyPath, context: context))
+                }
+    }
+
+    /// Maps data received from the signal into an array of objects
+    /// which implement the Mappable protocol and returns the result back
+    /// If the conversion fails, the signal errors.
+    public func mapArray<T: BaseMappable>(_ type: T.Type, atKeyPath keyPath: String, context: MapContext? = nil) -> Single<[T]> {
+        return flatMap { response -> Single<[T]> in
+                    return Single.just(try response.mapArray(type, atKeyPath: keyPath, context: context))
+                }
+    }
 }
 
 
@@ -51,6 +69,24 @@ public extension PrimitiveSequence where TraitType == SingleTrait, ElementType =
     public func mapArray<T: ImmutableMappable>(_ type: T.Type, context: MapContext? = nil) -> Single<[T]> {
         return flatMap { response -> Single<[T]> in
                     return Single.just(try response.mapArray(type, context: context))
+                }
+    }
+
+    /// Maps data received from the signal into an object
+    /// which implements the ImmutableMappable protocol and returns the result back
+    /// If the conversion fails, the signal errors.
+    public func mapObject<T: ImmutableMappable>(_ type: T.Type, atKeyPath keyPath: String, context: MapContext? = nil) -> Single<T> {
+        return flatMap { response -> Single<T> in
+                    return Single.just(try response.mapObject(type, atKeyPath: keyPath, context: context))
+                }
+    }
+
+    /// Maps data received from the signal into an array of objects
+    /// which implement the ImmutableMappable protocol and returns the result back
+    /// If the conversion fails, the signal errors.
+    public func mapArray<T: ImmutableMappable>(_ type: T.Type, atKeyPath keyPath: String, context: MapContext? = nil) -> Single<[T]> {
+        return flatMap { response -> Single<[T]> in
+                    return Single.just(try response.mapArray(type, atKeyPath: keyPath, context: context))
                 }
     }
 }


### PR DESCRIPTION
JSON
```
{
  "count":2,
  "rows": [
     {"id":1, "description":"Description 1"},
     {"id":2", "description":"Description 2"}
  ]
}
```

Usage with RxSwift
```
SomeProvider.request(.getItems()).mapArray(Item.self, atKeyPath: "rows")
```