### PR TITLE
Per issue 90, re-added Moya/RxSwift as a dependency of subspec RxSwif…

### DIFF
--- a/Moya-ObjectMapper.podspec
+++ b/Moya-ObjectMapper.podspec
@@ -29,13 +29,14 @@ Pod::Spec.new do |s|
 
   s.subspec "RxSwift" do |ss|
     ss.source_files = "Source/RxSwift/*.swift"
+    ss.dependency "Moya/RxSwift"
     ss.dependency "Moya-ObjectMapper/Core"
     ss.dependency "RxSwift", '~> 4.1'
   end
 
   s.subspec "ReactiveSwift" do |ss|
     ss.source_files = "Source/ReactiveSwift/*.swift"
-    ss.dependency "Moya-ObjectMapper/Core" 
+    ss.dependency "Moya-ObjectMapper/Core"
     ss.dependency "Moya/ReactiveSwift", '11'
     ss.dependency "ReactiveSwift", "~> 3"
    end


### PR DESCRIPTION
…t so that users of the library don't have to manually import it